### PR TITLE
TAL-764: Synchronize file rolling for multiple processes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ parking_lot = { version = "0.12.0", optional = true }
 thiserror = "1.0.15"
 anyhow = "1.0.28"
 derivative = "2.1.1"
+fslock = "0.2.1"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", optional = true, features = ["handleapi", "minwindef", "processenv", "winbase", "wincon"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,12 @@ all_components = [
 
 gzip = ["flate2"]
 
+# [[bench]]
+# name = "rotation"
+# harness = false
+
 [[bench]]
-name = "rotation"
+name = "multiprocess_sync"
 harness = false
 
 [dependencies]
@@ -82,6 +86,7 @@ lazy_static = "1.4"
 streaming-stats = "0.2.3"
 humantime = "2.0"
 tempfile = "3.1.0"
+criterion = "0.2.11"
 
 [[example]]
 name = "json_logger"

--- a/benches/multiprocess_sync.rs
+++ b/benches/multiprocess_sync.rs
@@ -1,0 +1,50 @@
+#[macro_use]
+extern crate criterion;
+
+use std::{env, fs::OpenOptions, io::{BufWriter, Write}};
+
+use criterion::Criterion;
+use log::Record;
+use log4rs::{append::{rolling_file::{policy::{compound::{roll::{fixed_window::FixedWindowRoller, Roll}, CompoundPolicy, trigger::size::SizeTrigger}}, LogWriter, RollingFileAppender}, Append}, encode::pattern::PatternEncoder};
+
+fn roll_benchmark(c: &mut Criterion) {
+    let active_file = env::temp_dir().join("log4rs-roll.log");
+    let roller = FixedWindowRoller::builder().build(active_file.with_extension("{}").to_str().unwrap(), 10).unwrap();
+    c.bench_function("::append::rolling_file::policy::compound::roll::fixed_window::roll", move |b| b.iter(|| {
+        roller.roll(&active_file).unwrap();
+    }));
+}
+
+fn write_benchmark(c: &mut Criterion) {
+    let file = OpenOptions::new()
+        .write(true)
+        .append(true)
+        .truncate(false)
+        .create(true)
+        .open(env::temp_dir().join("log4rs-write.log")).unwrap();
+
+    let mut writer = LogWriter {
+        file: BufWriter::new(file),
+        len: 0,
+    };
+    c.bench_function("::append::rolling_file::LogWriter::write", move |b| b.iter(|| {
+        writer.write("This is a log message".as_bytes()).unwrap();
+    }));
+}
+
+fn append_benchmark(c: &mut Criterion) {
+    let file_path = env::temp_dir().join("log4rs-append.log");
+    let roller = FixedWindowRoller::builder().build(file_path.with_extension("{}").to_str().unwrap(), 10).unwrap();
+    let policy = CompoundPolicy::new(Box::new(SizeTrigger::new(1)), Box::new(roller));
+    let appender = RollingFileAppender::builder()
+        .encoder(Box::new(PatternEncoder::default()))
+        .build(file_path, Box::new(policy)).unwrap();
+
+    let record = Record::builder().args(format_args!("This is a log message")).build();
+    c.bench_function("::append::rolling_file::RollingFileAppender::append", move |b| b.iter(|| {
+        appender.append(&record).unwrap();
+    }));
+}
+ 
+criterion_group!(benches, roll_benchmark, write_benchmark, append_benchmark);
+criterion_main!(benches);

--- a/benches/multiprocess_sync.rs
+++ b/benches/multiprocess_sync.rs
@@ -26,6 +26,7 @@ fn write_benchmark(c: &mut Criterion) {
     let mut writer = LogWriter {
         file: BufWriter::new(file),
         len: 0,
+        check_counter: 0,
     };
     c.bench_function("::append::rolling_file::LogWriter::write", move |b| b.iter(|| {
         writer.write("This is a log message".as_bytes()).unwrap();

--- a/benches/rotation.rs
+++ b/benches/rotation.rs
@@ -94,6 +94,7 @@ fn mk_config(file_size: u64, file_count: u32) -> log4rs::config::Config {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 struct Stats {
     min: Duration,
     max: Duration,

--- a/src/append/rolling_file/mod.rs
+++ b/src/append/rolling_file/mod.rs
@@ -81,9 +81,9 @@ impl<'de> serde::Deserialize<'de> for Policy {
 }
 
 #[derive(Debug)]
-struct LogWriter {
-    file: BufWriter<File>,
-    len: u64,
+pub struct LogWriter {
+    pub file: BufWriter<File>,
+    pub len: u64,
 }
 
 impl io::Write for LogWriter {
@@ -104,8 +104,8 @@ impl encode::Write for LogWriter {}
 /// Information about the active log file.
 #[derive(Debug)]
 pub struct LogFile<'a> {
-    writer: &'a mut Option<LogWriter>,
-    path: &'a Path,
+    pub writer: &'a mut Option<LogWriter>,
+    pub path: &'a Path,
     len: u64,
 }
 

--- a/src/append/rolling_file/mod.rs
+++ b/src/append/rolling_file/mod.rs
@@ -89,7 +89,10 @@ pub struct LogWriter {
 impl io::Write for LogWriter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.file.write(buf).map(|n| {
-            self.len += n as u64;
+            match self.file.get_ref().metadata().map(|meta| meta.len()).ok() {
+                Some(file_size) => self.len = file_size,
+                None => self.len += n as u64
+            }
             n
         })
     }

--- a/src/append/rolling_file/mod.rs
+++ b/src/append/rolling_file/mod.rs
@@ -90,7 +90,7 @@ pub struct LogWriter {
 impl io::Write for LogWriter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.file.write(buf).map(|n| {
-            if self.check_counter % 5 == 0 {
+            if self.check_counter % 10 == 0 {
                 match self.file.get_ref().metadata().map(|meta| meta.len()).ok() {
                     Some(file_size) => self.len = file_size,
                     None => self.len += n as u64
@@ -98,7 +98,7 @@ impl io::Write for LogWriter {
             } else {
                 self.len += n as u64
             }
-            // self.check_counter += 1;
+            self.check_counter += 1;
             n
         })
     }

--- a/src/append/rolling_file/policy/compound/mod.rs
+++ b/src/append/rolling_file/policy/compound/mod.rs
@@ -101,7 +101,14 @@ impl CompoundPolicy {
 
 impl Policy for CompoundPolicy {
     fn process(&self, log: &mut LogFile) -> anyhow::Result<()> {
+        let mut lockfile = fslock::LockFile::open(&log.path.with_extension("lock"))?;
+        if !lockfile.try_lock()? {
+            log.roll();
+             // Another process will roll the files
+            return Ok(())
+        }
         if self.trigger.trigger(log)? {
+            // println!("[ {} ] ( {} ) Rolling", chrono::Local::now().format("%Y-%m-%d][%H:%M:%S.%f"), std::process::id());
             log.roll();
             self.roller.roll(log.path())?;
         }

--- a/src/append/rolling_file/policy/compound/roll/fixed_window.rs
+++ b/src/append/rolling_file/policy/compound/roll/fixed_window.rs
@@ -168,6 +168,7 @@ where
     P: AsRef<Path>,
     Q: AsRef<Path>,
 {
+    println!("moving {} to {}", src.as_ref().display(), dst.as_ref().display());
     // first try a rename
     match fs::rename(src.as_ref(), dst.as_ref()) {
         Ok(()) => return Ok(()),

--- a/src/append/rolling_file/policy/compound/trigger/mod.rs
+++ b/src/append/rolling_file/policy/compound/trigger/mod.rs
@@ -13,6 +13,9 @@ pub mod size;
 pub trait Trigger: fmt::Debug + Send + Sync + 'static {
     /// Determines if the active log file should be rolled over.
     fn trigger(&self, file: &LogFile) -> anyhow::Result<bool>;
+
+    /// double check for the multiprocess rolling case to prevent a race condition
+    fn verify(&self, file: &LogFile) -> bool;
 }
 
 #[cfg(feature = "config_parsing")]

--- a/src/append/rolling_file/policy/compound/trigger/size.rs
+++ b/src/append/rolling_file/policy/compound/trigger/size.rs
@@ -121,6 +121,15 @@ impl Trigger for SizeTrigger {
         // }
         Ok(file.len_fs() > self.limit)
     }
+
+    fn verify (&self, file: &LogFile) -> bool {
+        //check to see if another process rolled the file and we're pointing at a smaller file now
+        let size = ::std::fs::metadata(file.path).map(|meta| meta.len()).ok();
+        match size {
+            Some(size) => size >= self.limit,
+            _ => false
+        }
+    }
 }
 
 /// A deserializer for the `SizeTrigger`.

--- a/src/append/rolling_file/policy/compound/trigger/size.rs
+++ b/src/append/rolling_file/policy/compound/trigger/size.rs
@@ -115,11 +115,11 @@ impl SizeTrigger {
 
 impl Trigger for SizeTrigger {
     fn trigger(&self, file: &LogFile) -> anyhow::Result<bool> {
-        // if file.len_fs() > self.limit {
+        // if file.len_estimate() > self.limit {
         //     println!("( {} ) File size: {}, Limit: {}", std::process::id(), file.len_estimate(), self.limit);
         //     println!("( {} ) Actual file size: {}", std::process::id(), file.len_fs());
         // }
-        Ok(file.len_fs() > self.limit)
+        Ok(file.len_estimate() > self.limit)
     }
 
     fn verify (&self, file: &LogFile) -> bool {

--- a/src/append/rolling_file/policy/compound/trigger/size.rs
+++ b/src/append/rolling_file/policy/compound/trigger/size.rs
@@ -115,7 +115,11 @@ impl SizeTrigger {
 
 impl Trigger for SizeTrigger {
     fn trigger(&self, file: &LogFile) -> anyhow::Result<bool> {
-        Ok(file.len_estimate() > self.limit)
+        // if file.len_fs() > self.limit {
+        //     println!("( {} ) File size: {}, Limit: {}", std::process::id(), file.len_estimate(), self.limit);
+        //     println!("( {} ) Actual file size: {}", std::process::id(), file.len_fs());
+        // }
+        Ok(file.len_fs() > self.limit)
     }
 }
 


### PR DESCRIPTION
Use OS-specific file lock APIs to synchronize rolling log files between processes. Similar to https://github.com/estk/log4rs/compare/master...paul-tcell:log4rs:support_multiprocess_rolling but adds Windows support using the crate `fslock`.

Benches comparing log4rs v1.1 and this changeset:

```
     Running benches/multiprocess_sync.rs (target/release/deps/multiprocess_sync-5dc88e178ff980ab)
Gnuplot not found, disabling plotting
::append::rolling_file::policy::compound::roll::fixed_window::roll
                        time:   [92.669 us 95.242 us 98.214 us]
                        change: [+82.800% +87.689% +92.506%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

::append::rolling_file::LogWriter::write
                        time:   [57.430 ns 58.011 ns 58.678 ns]
                        change: [+119.71% +123.31% +127.32%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  3 (3.00%) high severe

::append::rolling_file::RollingFileAppender::append - roll
                        time:   [1.3414 ms 1.3661 ms 1.3886 ms]
                        change: [+18.687% +21.445% +24.370%] (p = 0.00 < 0.05)
                        Performance has regressed.

::append::rolling_file::RollingFileAppender::append - no roll
                        time:   [6.8075 us 7.0809 us 7.3840 us]
                        change: [+27.024% +33.273% +40.584%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 12 outliers among 100 measurements (12.00%)
  2 (2.00%) high mild
  10 (10.00%) high severe
```

Performance is worse, but not bad. Performance with `fslock` is basically identical to @pcallahan's original custom impl, which we have been using for several years.